### PR TITLE
Add Terraform configuration files for SSO

### DIFF
--- a/terraform/sso/aws/README.md
+++ b/terraform/sso/aws/README.md
@@ -1,0 +1,37 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cognito_user_pool.omd_user_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [aws_cognito_user_pool_client.userpool_client](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) | resource |
+| [aws_cognito_user_pool_domain.omd_user_pool_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_client_callback_urls"></a> [client\_callback\_urls](#input\_client\_callback\_urls) | List of allowed callback URLs for the identity provider | `list(string)` | <pre>[<br>  "http://localhost:8585/callback"<br>]</pre> | no |
+| <a name="input_from_email_address"></a> [from\_email\_address](#input\_from\_email\_address) | Sender's email address or sender's display name with their email address | `string` | `"no-reply@verificationemail.com"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for AWS Cognito User Pool | `string` | `"us-east-1"` | no |
+| <a name="input_user_pool_alias_attributes"></a> [user\_pool\_alias\_attributes](#input\_user\_pool\_alias\_attributes) | Attributes supported as an alias for the user pool | `list(string)` | <pre>[<br>  "email"<br>]</pre> | no |
+| <a name="input_user_pool_client_name"></a> [user\_pool\_client\_name](#input\_user\_pool\_client\_name) | Name of the application client | `string` | `"app-OMD"` | yes |
+| <a name="input_user_pool_domain"></a> [user\_pool\_domain](#input\_user\_pool\_domain) | Domain for user pool | `string` | `"openmetadata"` | yes |
+| <a name="input_user_pool_name"></a> [user\_pool\_name](#input\_user\_pool\_name) | Name for the Cognito user pool | `string` | `"OMD Pool"` | yes |
+
+## Outputs
+
+No outputs.

--- a/terraform/sso/aws/provider.tf
+++ b/terraform/sso/aws/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/sso/aws/user_pool.tf
+++ b/terraform/sso/aws/user_pool.tf
@@ -1,0 +1,27 @@
+resource "aws_cognito_user_pool" "omd_user_pool" {
+  name = var.user_pool_name
+  alias_attributes  = var.user_pool_alias_attributes
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  email_configuration {
+    email_sending_account = "COGNITO_DEFAULT"
+    from_email_address    = var.from_email_address
+  }
+}
+
+resource "aws_cognito_user_pool_domain" "omd_user_pool_domain" {
+  domain       = var.user_pool_domain
+  user_pool_id = aws_cognito_user_pool.omd_user_pool.id
+}
+
+resource "aws_cognito_user_pool_client" "userpool_client" {
+  name                                 = var.user_pool_client_name
+  user_pool_id                         = aws_cognito_user_pool.omd_user_pool.id
+  callback_urls                        = var.client_callback_urls
+}

--- a/terraform/sso/aws/variables.tf
+++ b/terraform/sso/aws/variables.tf
@@ -1,0 +1,41 @@
+variable region {
+    type        = string
+    description = "Region for AWS Cognito User Pool"
+    default     = "us-east-1"
+}
+
+variable user_pool_name {
+    type        = string
+    description = "Name for the Cognito user pool"
+    default     = "OMD Pool"
+}
+
+variable user_pool_alias_attributes {
+    type        = list(string)
+    description = "Attributes supported as an alias for the user pool"
+    default     = ["email"]
+}
+
+variable from_email_address {
+    type        = string
+    description = "Sender's email address or sender's display name with their email address"
+    default     = "no-reply@verificationemail.com"
+}
+
+variable user_pool_domain {
+    type        = string
+    description = "Domain for user pool"
+    default     = "openmetadata"
+}
+
+variable user_pool_client_name {
+    type        = string
+    description = "Name of the application client"
+    default     = "app-OMD"
+}
+
+variable client_callback_urls {
+    type        = list(string)
+    description = "List of allowed callback URLs for the identity provider"
+    default     = ["http://localhost:8585/callback"]
+}

--- a/terraform/sso/keycloak/README.md
+++ b/terraform/sso/keycloak/README.md
@@ -1,0 +1,36 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_keycloak"></a> [keycloak](#provider\_keycloak) | 4.4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [keycloak_openid_client.openid_client](https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client) | resource |
+| [keycloak_realm.omd_realm](https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/realm) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_keycloak_url"></a> [keycloak\_url](#input\_keycloak\_url) | The URL of the Keycloak instance | `string` | `"http://localhost:8080"` | yes |
+| <a name="input_openid_client_id"></a> [openid\_client\_id](#input\_openid\_client\_id) | The Client ID for this client, referenced in the URI during authentication and in issued tokens | `string` | `"open-metadata"` | yes |
+| <a name="input_post_logout_redirect_uris"></a> [post\_logout\_redirect\_uris](#input\_post\_logout\_redirect\_uris) | A list of valid URIs a browser is permitted to redirect to after a successful logout | `list(string)` | <pre>[<br>  "http://localhost:8585"<br>]</pre> | no |
+| <a name="input_realm"></a> [realm](#input\_realm) | The name of the realm | `string` | `"omd-realm"` | yes |
+| <a name="input_realm_display_name"></a> [realm\_display\_name](#input\_realm\_display\_name) | The display name for the realm that is shown when logging in to the admin console | `string` | `"OMD Realm"` | no |
+| <a name="input_redirect_uris"></a> [redirect\_uris](#input\_redirect\_uris) | A list of valid URIs a browser is permitted to redirect to after a successful login | `list(string)` | <pre>[<br>  "http://localhost:8585",<br>  "http://localhost:8585/callback"<br>]</pre> | no |
+| <a name="input_web_origins"></a> [web\_origins](#input\_web\_origins) | A list of allowed CORS origins | `list(string)` | <pre>[<br>  "http://localhost:8585"<br>]</pre> | no |
+
+## Outputs
+
+No outputs.

--- a/terraform/sso/keycloak/keycloak_oidc.tf
+++ b/terraform/sso/keycloak/keycloak_oidc.tf
@@ -1,0 +1,18 @@
+resource "keycloak_openid_client" "openid_client" {
+  realm_id            = keycloak_realm.omd_realm.id
+  client_id           = var.openid_client_id
+  enabled             = true
+
+  access_type         = "CONFIDENTIAL"
+
+  standard_flow_enabled = true
+  implicit_flow_enabled = true
+  direct_access_grants_enabled  = true
+  service_accounts_enabled  = true
+
+  valid_redirect_uris = var.redirect_uris
+
+  valid_post_logout_redirect_uris = var.post_logout_redirect_uris
+
+  web_origins = var.web_origins
+}

--- a/terraform/sso/keycloak/provider.tf
+++ b/terraform/sso/keycloak/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    keycloak = {
+      source = "mrparkers/keycloak"
+    }
+  }
+}
+
+provider "keycloak" {
+  client_id     = "admin-cli"
+  url           = var.keycloak_url
+}

--- a/terraform/sso/keycloak/realm.tf
+++ b/terraform/sso/keycloak/realm.tf
@@ -1,0 +1,5 @@
+resource "keycloak_realm" "omd_realm" {
+  realm             = var.realm
+  enabled           = true
+  display_name      = var.realm_display_name
+}

--- a/terraform/sso/keycloak/variables.tf
+++ b/terraform/sso/keycloak/variables.tf
@@ -1,0 +1,41 @@
+variable keycloak_url {
+    type        = string
+    description = "The URL of the Keycloak instance"
+    default     = "http://localhost:8080"
+}
+
+variable realm {
+    type        = string
+    description = "The name of the realm"
+    default     = "omd-realm"
+}
+
+variable realm_display_name {
+    type        = string
+    description = "The display name for the realm that is shown when logging in to the admin console"
+    default     = "OMD Realm"
+}
+
+variable openid_client_id {
+    type        = string
+    description = "The Client ID for this client, referenced in the URI during authentication and in issued tokens"
+    default     = "open-metadata"
+}
+
+variable redirect_uris {
+    type        = list(string)
+    description = "A list of valid URIs a browser is permitted to redirect to after a successful login"
+    default     = ["http://localhost:8585", "http://localhost:8585/callback"]
+}
+
+variable post_logout_redirect_uris {
+    type        = list(string)
+    description = "A list of valid URIs a browser is permitted to redirect to after a successful logout"
+    default     = ["http://localhost:8585"]
+}
+
+variable web_origins {
+    type        = list(string)
+    description = "A list of allowed CORS origins"
+    default     = ["http://localhost:8585"]
+}

--- a/terraform/sso/okta/README.md
+++ b/terraform/sso/okta/README.md
@@ -1,0 +1,49 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_okta"></a> [okta](#provider\_okta) | 4.6.3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [okta_app_oauth.app_omd](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_oauth) | resource |
+| [okta_auth_server.server_omd](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/auth_server) | resource |
+| [okta_auth_server_policy.policy_omd_server](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/auth_server_policy) | resource |
+| [okta_auth_server_policy_rule.rule_omd_server_policy](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/auth_server_policy_rule) | resource |
+| [okta_auth_server_scope.scope_omd_server](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/auth_server_scope) | resource |
+| [okta_trusted_origin.to_omd](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/trusted_origin) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_auth_server_client_whitelist"></a> [auth\_server\_client\_whitelist](#input\_auth\_server\_client\_whitelist) | The clients to whitelist the policy for | `list(string)` | <pre>[<br>  "ALL_CLIENTS"<br>]</pre> | yes |
+| <a name="input_auth_server_name"></a> [auth\_server\_name](#input\_auth\_server\_name) | Authorizer Server Name | `string` | `"Openmetadata Server"` | yes |
+| <a name="input_auth_server_policy_grant_type"></a> [auth\_server\_policy\_grant\_type](#input\_auth\_server\_policy\_grant\_type) | List of accepted grant type values for the policy rule | `list(string)` | <pre>[<br>  "client_credentials",<br>  "authorization_code",<br>  "urn:ietf:params:oauth:grant-type:token-exchange",<br>  "urn:ietf:params:oauth:grant-type:device_code"<br>]</pre> | yes |
+| <a name="input_auth_server_policy_groups"></a> [auth\_server\_policy\_groups](#input\_auth\_server\_policy\_groups) | Specifies a set of Groups whose Users are to be included for the policy rule | `list(string)` | <pre>[<br>  "EVERYONE"<br>]</pre> | no |
+| <a name="input_auth_server_policy_name"></a> [auth\_server\_policy\_name](#input\_auth\_server\_policy\_name) | Name for policy created for Authorizer server | `string` | `"OMD_Server_Policy"` | yes |
+| <a name="input_auth_server_policy_rule"></a> [auth\_server\_policy\_rule](#input\_auth\_server\_policy\_rule) | Name of the Authorization Server Policy Rule | `string` | `"OMD Server Policy Rule"` | yes |
+| <a name="input_auth_server_policy_scope"></a> [auth\_server\_policy\_scope](#input\_auth\_server\_policy\_scope) | List of Scopes allowed for the policy rule | `list(string)` | <pre>[<br>  "*"<br>]</pre> | yes |
+| <a name="input_auth_server_scope_name"></a> [auth\_server\_scope\_name](#input\_auth\_server\_scope\_name) | Scope for Authorizer server | `string` | `"Scope_for_OMD_server"` | yes |
+| <a name="input_base_url"></a> [base\_url](#input\_base\_url) | Base URL of Okta | `string` | `"okta.com"` | no |
+| <a name="input_logout_redirect_uris"></a> [logout\_redirect\_uris](#input\_logout\_redirect\_uris) | List of URIs for redirection after logout | `list(string)` | <pre>[<br>  "http://localhost:8585"<br>]</pre> | no |
+| <a name="input_oauth_app_grant_types"></a> [oauth\_app\_grant\_types](#input\_oauth\_app\_grant\_types) | List of OAuth 2.0 grant types for OIDC app | `list(string)` | <pre>[<br>  "authorization_code",<br>  "refresh_token",<br>  "implicit"<br>]</pre> | no |
+| <a name="input_oauth_app_label"></a> [oauth\_app\_label](#input\_oauth\_app\_label) | Label of the OIDC app | `string` | `"App-Openmetadata"` | yes |
+| <a name="input_org_name"></a> [org\_name](#input\_org\_name) | Organization name for Okta | `string` | `"trial-6795048"` | no |
+| <a name="input_redirect_uris"></a> [redirect\_uris](#input\_redirect\_uris) | List of URIs for use in the redirect-based flow | `list(string)` | <pre>[<br>  "http://localhost:8585/callback",<br>  "http://localhost:8585/silent-callback"<br>]</pre> | no |
+| <a name="input_trusted_origin_name"></a> [trusted\_origin\_name](#input\_trusted\_origin\_name) | Name of the Trusted Origin | `string` | `"Openmetadata Trusted Origin"` | yes |
+| <a name="input_trusted_origin_url"></a> [trusted\_origin\_url](#input\_trusted\_origin\_url) | URL of the Trusted Origin | `string` | `"http://localhost:8585"` | yes |
+
+## Outputs
+
+No outputs.

--- a/terraform/sso/okta/auth_server.tf
+++ b/terraform/sso/okta/auth_server.tf
@@ -1,0 +1,35 @@
+resource "okta_auth_server" "server_omd" {
+  audiences   = ["${okta_app_oauth.app_omd.client_id}"]
+  description = "Authorizer for Opemetadata Application"
+  name        = var.auth_server_name
+  issuer_mode = "ORG_URL"
+  status      = "ACTIVE"
+}
+
+resource "okta_auth_server_scope" "scope_omd_server" {
+  auth_server_id   = okta_auth_server.server_omd.id
+  name             = var.auth_server_scope_name
+  default          = true
+  depends_on       = [okta_auth_server.server_omd]
+  consent          = "IMPLICIT"
+}
+
+resource "okta_auth_server_policy" "policy_omd_server" {
+  auth_server_id   = okta_auth_server.server_omd.id
+  status           = "ACTIVE"
+  name             = var.auth_server_policy_name
+  description      = "Authorizer Server  policy for Openmetadata Server"
+  priority         = 1
+  client_whitelist = var.auth_server_client_whitelist
+}
+
+resource "okta_auth_server_policy_rule" "rule_omd_server_policy" {
+  auth_server_id       = okta_auth_server.server_omd.id
+  policy_id            = okta_auth_server_policy.policy_omd_server.id
+  status               = "ACTIVE"
+  name                 = var.auth_server_policy_rule
+  priority             = 1
+  grant_type_whitelist = var.auth_server_policy_grant_type
+  scope_whitelist      = var.auth_server_policy_scope
+  group_whitelist      = var.auth_server_policy_groups
+}

--- a/terraform/sso/okta/oauth_app.tf
+++ b/terraform/sso/okta/oauth_app.tf
@@ -1,0 +1,9 @@
+resource "okta_app_oauth" "app_omd" {
+  label                      = var.oauth_app_label
+  type                       = "browser"
+  grant_types                = var.oauth_app_grant_types
+  redirect_uris              = var.redirect_uris
+  post_logout_redirect_uris  = var.logout_redirect_uris
+  implicit_assignment        = true
+  response_types             = ["token", "code"]
+}

--- a/terraform/sso/okta/provider.tf
+++ b/terraform/sso/okta/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    okta = {
+      source = "okta/okta"
+    }
+  }
+}
+
+provider "okta" {
+  org_name = var.org_name
+  base_url = var.base_url
+}

--- a/terraform/sso/okta/trusted_origin.tf
+++ b/terraform/sso/okta/trusted_origin.tf
@@ -1,0 +1,5 @@
+resource "okta_trusted_origin" "to_omd" {
+  name   = var.trusted_origin_name
+  origin = var.trusted_origin_url
+  scopes = ["REDIRECT"]
+}

--- a/terraform/sso/okta/variables.tf
+++ b/terraform/sso/okta/variables.tf
@@ -1,0 +1,95 @@
+variable org_name {
+    type        = string
+    description = "Organization name for Okta"
+    default     = "trial-6795048"
+}
+
+variable base_url {
+    type        = string
+    description = "Base URL of Okta"
+    default     = "okta.com"
+}
+
+variable trusted_origin_name {
+    type        = string
+    description = "Name of the Trusted Origin"
+    default     = "Openmetadata Trusted Origin"
+}
+
+variable trusted_origin_url {
+    type        = string
+    description = "URL of the Trusted Origin"
+    default     = "http://localhost:8585"
+}
+
+variable oauth_app_label {
+    type        = string
+    description = "Label of the OIDC app"
+    default     = "App-Openmetadata"
+}
+
+variable oauth_app_grant_types {
+    type        = list(string)
+    description = "List of OAuth 2.0 grant types for OIDC app"
+    default     = ["authorization_code", "refresh_token", "implicit"]
+}
+
+variable redirect_uris {
+    type        = list(string)
+    description = "List of URIs for use in the redirect-based flow"
+    default     = ["http://localhost:8585/callback", "http://localhost:8585/silent-callback"]
+}
+
+variable logout_redirect_uris {
+    type        = list(string)
+    description = "List of URIs for redirection after logout"
+    default     = ["http://localhost:8585"]
+}
+
+variable auth_server_name {
+    type        = string
+    description = "Authorizer Server Name"
+    default     = "Openmetadata Server"
+}
+
+variable auth_server_scope_name {
+    type        = string
+    description = "Scope for Authorizer server"
+    default     = "Scope_for_OMD_server"
+}
+
+variable auth_server_policy_name {
+    type        = string
+    description = "Name for policy created for Authorizer server"
+    default     = "OMD_Server_Policy"
+}
+
+variable auth_server_client_whitelist {
+    type        = list(string)
+    description = "The clients to whitelist the policy for"
+    default     = ["ALL_CLIENTS"]
+}
+
+variable auth_server_policy_rule {
+    type        = string
+    description = "Name of the Authorization Server Policy Rule"
+    default     = "OMD Server Policy Rule"
+}
+
+variable auth_server_policy_grant_type {
+    type        = list(string)
+    description = "List of accepted grant type values for the policy rule"
+    default     = ["client_credentials", "authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange", "urn:ietf:params:oauth:grant-type:device_code"]
+}
+
+variable auth_server_policy_scope {
+    type        = list(string)
+    description = "List of Scopes allowed for the policy rule"
+    default     = ["*"]
+}
+
+variable auth_server_policy_groups {
+    type        = list(string)
+    description = "Specifies a set of Groups whose Users are to be included for the policy rule"
+    default     = ["EVERYONE"]
+}


### PR DESCRIPTION
This Pull request includes Terraform configuration files for 3 sorts of SSO.

1. SSO via [AWS Congito](https://docs.open-metadata.org/v1.2.x/deployment/security/amazon-cognito)
2. SSO via [Keycloak](https://docs.open-metadata.org/v1.2.x/deployment/security/keycloak)
3. SSO via [Okta](https://docs.open-metadata.org/v1.2.x/deployment/security/okta)

These configuration files includes the minimum required settings in order to setup SSO.