### PR TITLE
chore: ecr registry helper resources must be optional

### DIFF
--- a/terraform/hybrid-ingestion-runner/aws/ecr-registry-helper.tf
+++ b/terraform/hybrid-ingestion-runner/aws/ecr-registry-helper.tf
@@ -2,7 +2,7 @@
 
 locals {
   docker_registry = "https://118146679784.dkr.ecr.eu-west-1.amazonaws.com"
-  registry_helper_manifest = yamldecode(<<-EOF
+  registry_helper_manifest = var.ECR_ACCESS_KEY == null ? "" : yamldecode(<<-EOF
   serviceAccountName : "${kubernetes_service_account_v1.omd_cron_sa[0].metadata[0].name}"
   containers:
     - name: "ecr-registry-helper"


### PR DESCRIPTION
If Access keys are provided as null, it should not create any resource for it

Fixes: https://github.com/open-metadata/openmetadata-deployment/issues/24